### PR TITLE
Add GraphEngine starter modules

### DIFF
--- a/graph-engine/README.md
+++ b/graph-engine/README.md
@@ -1,0 +1,17 @@
+# Graph Engine Starter
+
+This is a starter implementation of a graph visualization engine built on top of **diagram-js**.
+
+## Modules
+
+* **Core** – initializes the diagram and exposes basic graph manipulation API.
+* **Custom Renderer** – draws nodes and edges with SVG.
+* **Model** – stores custom data on elements.
+* **Layout** – placeholder for automatic layout integration.
+* **Interaction** – hooks for basic user interactions.
+* **React Wrapper** – `<GraphCanvas />` component for React.
+* **Style System** – basic CSS classes for nodes and edges.
+* **Events** – common event names.
+* **Data Import/Export** – helper functions to load and save graphs.
+
+This code is only a minimal skeleton and does not include advanced features such as nesting or complex interactions. Use it as a starting point for further development.

--- a/graph-engine/lib/core/GraphEngineCore.js
+++ b/graph-engine/lib/core/GraphEngineCore.js
@@ -1,0 +1,54 @@
+// GraphEngineCore provides basic graph manipulation API
+
+export default {
+  __init__: [ 'graphEngineCore' ],
+  graphEngineCore: [ 'type', GraphEngineCore ]
+};
+
+/**
+ * @param {Canvas} canvas
+ * @param {ElementRegistry} elementRegistry
+ * @param {Modeling} modeling
+ * @param {CommandStack} commandStack
+ */
+function GraphEngineCore(canvas, elementRegistry, modeling, commandStack) {
+  this.canvas = canvas;
+  this.elementRegistry = elementRegistry;
+  this.modeling = modeling;
+  this.commandStack = commandStack;
+}
+
+GraphEngineCore.$inject = [ 'canvas', 'elementRegistry', 'modeling', 'commandStack' ];
+
+GraphEngineCore.prototype.addNode = function(node) {
+  // placeholder: add shape to canvas
+  this.modeling.createShape(node, node.position, node.parent);
+};
+
+GraphEngineCore.prototype.addEdge = function(edge) {
+  // placeholder: add connection between nodes
+  this.modeling.connect(edge.source, edge.target, edge);
+};
+
+GraphEngineCore.prototype.removeElement = function(id) {
+  const element = this.elementRegistry.get(id);
+  if (element) {
+    this.modeling.removeElements([ element ]);
+  }
+};
+
+GraphEngineCore.prototype.getElement = function(id) {
+  return this.elementRegistry.get(id);
+};
+
+GraphEngineCore.prototype.getGraph = function() {
+  return {
+    nodes: this.elementRegistry.filter(e => e.type === 'node'),
+    edges: this.elementRegistry.filter(e => e.type === 'edge')
+  };
+};
+
+GraphEngineCore.prototype.clear = function() {
+  const elements = this.elementRegistry.getAll();
+  this.modeling.removeElements(elements);
+};

--- a/graph-engine/lib/data/GraphIO.js
+++ b/graph-engine/lib/data/GraphIO.js
@@ -1,0 +1,17 @@
+// Simple JSON import/export helpers
+
+export function exportJSON(engine) {
+  return JSON.stringify(engine.api.getGraph(), null, 2);
+}
+
+export function importJSON(engine, json) {
+  const data = JSON.parse(json);
+
+  if (data.nodes) {
+    data.nodes.forEach(n => engine.api.addNode(n));
+  }
+
+  if (data.edges) {
+    data.edges.forEach(e => engine.api.addEdge(e));
+  }
+}

--- a/graph-engine/lib/events/index.js
+++ b/graph-engine/lib/events/index.js
@@ -1,0 +1,7 @@
+// re-export event names for convenience
+export const ELEMENT_CLICK = 'element.click';
+export const ELEMENT_HOVER = 'element.hover';
+export const ELEMENT_DRAGSTART = 'element.dragstart';
+export const ELEMENT_DRAGEND = 'element.dragend';
+export const CANVAS_ZOOM = 'canvas.zoom';
+export const LAYOUT_DONE = 'layout.done';

--- a/graph-engine/lib/index.js
+++ b/graph-engine/lib/index.js
@@ -1,0 +1,36 @@
+// GraphEngine root export
+// Provides initialization and high level API
+
+import Diagram from '../../lib/Diagram.js';
+import GraphEngineCore from './core/GraphEngineCore.js';
+import GraphRendererModule from './renderer/GraphRenderer.js';
+import GraphModelModule from './model/GraphModel.js';
+import GraphLayoutModule from './layout/GraphLayout.js';
+import GraphInteractionModule from './interaction/GraphInteraction.js';
+
+// diagram-js modules loaded by the engine
+const defaultModules = [
+  GraphEngineCore,
+  GraphRendererModule,
+  GraphModelModule,
+  GraphLayoutModule,
+  GraphInteractionModule
+];
+
+export default class GraphEngine {
+  constructor(options = {}) {
+    const { container, modules = [] } = options;
+
+    this.diagram = new Diagram({
+      canvas: { container },
+      modules: [ ...defaultModules, ...modules ]
+    });
+
+    // expose core API
+    this.core = this.diagram.get('graphEngineCore');
+  }
+
+  get api() {
+    return this.core;
+  }
+}

--- a/graph-engine/lib/interaction/GraphInteraction.js
+++ b/graph-engine/lib/interaction/GraphInteraction.js
@@ -1,0 +1,17 @@
+// Basic interaction hooks
+
+export default {
+  __init__: [ 'graphInteraction' ],
+  graphInteraction: [ 'type', GraphInteraction ]
+};
+
+function GraphInteraction(eventBus) {
+  this.eventBus = eventBus;
+
+  // example: log element clicks
+  eventBus.on('element.click', event => {
+    console.log('click', event.element.id);
+  });
+}
+
+GraphInteraction.$inject = [ 'eventBus' ];

--- a/graph-engine/lib/layout/GraphLayout.js
+++ b/graph-engine/lib/layout/GraphLayout.js
@@ -1,0 +1,19 @@
+// Placeholder layout module
+
+export default {
+  __init__: [ 'graphLayout' ],
+  graphLayout: [ 'type', GraphLayout ]
+};
+
+function GraphLayout(canvas, graphicsFactory) {
+  this.canvas = canvas;
+  this.graphicsFactory = graphicsFactory;
+}
+
+GraphLayout.$inject = [ 'canvas', 'graphicsFactory' ];
+
+GraphLayout.prototype.runLayout = function(options = {}) {
+  // TODO: integrate dagre or klay layout
+  // For now just noop
+  return Promise.resolve();
+};

--- a/graph-engine/lib/model/GraphModel.js
+++ b/graph-engine/lib/model/GraphModel.js
@@ -1,0 +1,38 @@
+// Model layer using elementRegistry as source of truth
+
+export default {
+  __init__: [ 'graphModel' ],
+  graphModel: [ 'type', GraphModel ]
+};
+
+function GraphModel(elementRegistry) {
+  this.elementRegistry = elementRegistry;
+}
+
+GraphModel.$inject = [ 'elementRegistry' ];
+
+GraphModel.prototype.addNode = function(node) {
+  node.businessObject = node.businessObject || {};
+  node.businessObject.data = node.data;
+};
+
+GraphModel.prototype.addEdge = function(edge) {
+  edge.businessObject = edge.businessObject || {};
+  edge.businessObject.data = edge.data;
+};
+
+GraphModel.prototype.updateData = function(id, data) {
+  const element = this.elementRegistry.get(id);
+  if (element) {
+    element.businessObject = element.businessObject || {};
+    element.businessObject.data = data;
+  }
+};
+
+GraphModel.prototype.getGraph = function() {
+  const elements = this.elementRegistry.getAll();
+  return {
+    nodes: elements.filter(e => e.type === 'node'),
+    edges: elements.filter(e => e.type === 'edge')
+  };
+};

--- a/graph-engine/lib/react/GraphCanvas.jsx
+++ b/graph-engine/lib/react/GraphCanvas.jsx
@@ -1,0 +1,40 @@
+import { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
+import GraphEngine from '../index.js';
+
+function GraphCanvas(props, ref) {
+  const { elements = [], layout = 'dagre', onSelect, onChange } = props;
+  const containerRef = useRef(null);
+  const engineRef = useRef(null);
+
+  useEffect(() => {
+    if (!engineRef.current) {
+      engineRef.current = new GraphEngine({ container: containerRef.current });
+    }
+
+    const engine = engineRef.current;
+
+    elements.forEach(el => {
+      if (el.group === 'nodes') {
+        engine.api.addNode(el);
+      } else if (el.group === 'edges') {
+        engine.api.addEdge(el);
+      }
+    });
+
+    if (layout) {
+      engine.diagram.get('graphLayout').runLayout({ name: layout });
+    }
+
+    if (onChange) {
+      onChange(engine.api.getGraph());
+    }
+  }, [ elements, layout, onChange ]);
+
+  useImperativeHandle(ref, () => ({
+    engine: () => engineRef.current
+  }), []);
+
+  return <div ref={ containerRef } style={{ width: '100%', height: '100%' }} />;
+}
+
+export default forwardRef(GraphCanvas);

--- a/graph-engine/lib/renderer/GraphRenderer.js
+++ b/graph-engine/lib/renderer/GraphRenderer.js
@@ -1,0 +1,47 @@
+// Custom renderer for nodes and edges
+import BaseRenderer from '../../lib/draw/Renderer.js';
+import { append as svgAppend, attr as svgAttr, create as svgCreate } from 'tiny-svg';
+
+export default {
+  __init__: [ 'graphRenderer' ],
+  graphRenderer: [ 'type', GraphRenderer ]
+};
+
+function GraphRenderer(eventBus, styles) {
+  BaseRenderer.call(this, eventBus, 2000);
+  this.styles = styles;
+}
+
+GraphRenderer.prototype = Object.create(BaseRenderer.prototype);
+
+GraphRenderer.$inject = [ 'eventBus', 'styles' ];
+
+GraphRenderer.prototype.drawShape = function(parentGfx, element) {
+  let shape;
+
+  if (element.type === 'node') {
+    shape = svgCreate('rect');
+    svgAttr(shape, { width: 80, height: 40, rx: 5, ry: 5 });
+  }
+
+  if (shape) {
+    svgAppend(parentGfx, shape);
+  }
+
+  return shape;
+};
+
+GraphRenderer.prototype.drawConnection = function(parentGfx, element) {
+  const path = svgCreate('path');
+  svgAttr(path, { d: this.getConnectionPath(element) });
+  svgAppend(parentGfx, path);
+  return path;
+};
+
+GraphRenderer.prototype.getConnectionPath = function(connection) {
+  const { waypoints } = connection;
+  if (!waypoints || waypoints.length === 0) {
+    return '';
+  }
+  return 'M' + waypoints.map(p => p.x + ',' + p.y).join('L');
+};

--- a/graph-engine/lib/style/default.css
+++ b/graph-engine/lib/style/default.css
@@ -1,0 +1,12 @@
+.graph-node {
+  fill: white;
+  stroke: black;
+}
+
+.graph-edge {
+  stroke: gray;
+}
+
+.graph-node.selected {
+  stroke: blue;
+}


### PR DESCRIPTION
## Summary
- scaffold `graph-engine` starter based on diagram-js
- implement minimal Core, Renderer, Model, Layout, Interaction modules
- add React component and helper utilities
- provide basic styles and documentation

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d516456d88331956916cc733b7820