### PR TITLE
Add hierarchy visualization module

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ Expose an environment variable `TEST_BROWSERS=(Chrome|Firefox)` to execute the t
 > [!NOTE]
 > We do not generate any build artifacts. Required parts of the library should be bundled by consuming libraries as needed instead.
 
+## Hierarchy visualization example
+
+A small module in `lib/features/hierarchy` demonstrates how to render hierarchical data.
+Use it as follows:
+
+```javascript
+import Diagram from "diagram-js/lib/Diagram";
+import HierarchyModule from "diagram-js/lib/features/hierarchy";
+
+const diagram = new Diagram({
+  canvas: { container: document.querySelector("#canvas") },
+  modules: [ HierarchyModule ]
+});
+
+diagram.get("hierarchyModeling").load(data);
+```
+
+
 
 ## License
 

--- a/lib/features/hierarchy/HierarchyLayout.js
+++ b/lib/features/hierarchy/HierarchyLayout.js
@@ -1,0 +1,41 @@
+export default function HierarchyLayout(modeling) {
+  this._modeling = modeling;
+}
+
+HierarchyLayout.$inject = [ 'modeling' ];
+
+HierarchyLayout.prototype.layout = function(nodes, edges) {
+  const levelHeight = 120;
+  const levelWidth = 200;
+
+  const childrenByParent = {};
+  edges.forEach(e => {
+    const pid = e.connection.source.id;
+    const arr = childrenByParent[pid] || (childrenByParent[pid] = []);
+    arr.push(e.connection.target);
+  });
+
+  const rootNodes = nodes.filter(n => !edges.some(e => e.connection.target === n));
+
+  const positionNode = (node, depth, index) => {
+    const x = index * levelWidth;
+    const y = depth * levelHeight;
+    const delta = { x: x - (node.x || 0), y: y - (node.y || 0) };
+    this._modeling.moveShape(node, delta);
+
+    const children = childrenByParent[node.id] || [];
+    children.forEach((child, i) => positionNode(child, depth + 1, i));
+  };
+
+  rootNodes.forEach((node, i) => positionNode(node, 0, i));
+
+  edges.forEach(e => {
+    const s = e.connection.source;
+    const t = e.connection.target;
+    const waypoints = [
+      { x: s.x + s.width / 2, y: s.y + s.height },
+      { x: t.x + t.width / 2, y: t.y }
+    ];
+    this._modeling.updateWaypoints(e.connection, waypoints);
+  });
+};

--- a/lib/features/hierarchy/HierarchyModeling.js
+++ b/lib/features/hierarchy/HierarchyModeling.js
@@ -1,0 +1,45 @@
+export default function HierarchyModeling(canvas, modeling, eventBus, hierarchyLayout) {
+  this._canvas = canvas;
+  this._modeling = modeling;
+  this._eventBus = eventBus;
+  this._hierarchyLayout = hierarchyLayout;
+}
+
+HierarchyModeling.$inject = [ 'canvas', 'modeling', 'eventBus', 'hierarchyLayout' ];
+
+HierarchyModeling.prototype.load = function(data) {
+  const root = this._canvas.getRootElement();
+  const nodes = {};
+  const edges = [];
+
+  data.nodes.forEach(n => {
+    const shape = this._modeling.createShape(
+      { id: n.id, width: 150, height: 70, type: 'hierarchy:node', businessObject: n },
+      { x: 0, y: 0 },
+      root
+    );
+    nodes[n.id] = shape;
+  });
+
+  data.edges.forEach(e => {
+    const connection = this._modeling.createConnection(
+      nodes[e.source],
+      nodes[e.target],
+      { id: e.source + '-' + e.target, type: 'hierarchy:edge', waypoints: [] },
+      root
+    );
+    edges.push({ data: e, connection });
+  });
+
+  this._nodes = nodes;
+  this._edges = edges;
+
+  this.layout();
+
+  this._eventBus.fire('hierarchy.loaded', { nodes, edges });
+};
+
+HierarchyModeling.prototype.layout = function() {
+  this._hierarchyLayout.layout(Object.values(this._nodes), this._edges);
+  this._eventBus.fire('hierarchy.layouted');
+};

--- a/lib/features/hierarchy/HierarchyRenderer.js
+++ b/lib/features/hierarchy/HierarchyRenderer.js
@@ -1,0 +1,73 @@
+import inherits from 'inherits-browser';
+import BaseRenderer from '../../draw/BaseRenderer';
+import { append as svgAppend, attr as svgAttr, create as svgCreate } from 'tiny-svg';
+
+const HIGH_PRIORITY = 1500;
+
+export default function HierarchyRenderer(eventBus, styles, hierarchyStyles) {
+  BaseRenderer.call(this, eventBus, HIGH_PRIORITY);
+  this._styles = styles;
+  this._hierarchyStyles = hierarchyStyles;
+}
+
+inherits(HierarchyRenderer, BaseRenderer);
+
+HierarchyRenderer.$inject = [ 'eventBus', 'styles', 'hierarchyStyles' ];
+
+HierarchyRenderer.prototype.canRender = function(element) {
+  return element.type === 'hierarchy:node' || element.type === 'hierarchy:edge';
+};
+
+HierarchyRenderer.prototype.drawShape = function(parent, element) {
+  const bo = element.businessObject || {};
+  const style = this._hierarchyStyles.getNodeStyle(bo);
+
+  const rect = svgCreate('rect');
+  svgAttr(rect, {
+    x: 0,
+    y: 0,
+    width: element.width,
+    height: element.height,
+    stroke: style.stroke,
+    fill: style.fill,
+    strokeWidth: 2,
+    rx: 4,
+    ry: 4
+  });
+
+  const text = svgCreate('text');
+  svgAttr(text, { x: 8, y: 20, 'font-size': '12' });
+  text.textContent = bo.label || '';
+
+  svgAppend(parent, rect);
+  svgAppend(parent, text);
+
+  return rect;
+};
+
+HierarchyRenderer.prototype.drawConnection = function(parent, connection) {
+  const path = connection.waypoints.map((p, idx) => (idx ? 'L' : 'M') + p.x + ',' + p.y).join(' ');
+  const line = svgCreate('path');
+  svgAttr(line, {
+    d: path,
+    stroke: '#555',
+    strokeWidth: 1.5,
+    fill: 'none'
+  });
+  svgAppend(parent, line);
+  return line;
+};
+
+HierarchyRenderer.prototype.getShapePath = function(shape) {
+  return [
+    'M', shape.x, shape.y,
+    'h', shape.width,
+    'v', shape.height,
+    'h', -shape.width,
+    'z'
+  ].join(' ');
+};
+
+HierarchyRenderer.prototype.getConnectionPath = function(connection) {
+  return connection.waypoints.map((p, i) => (i ? 'L' : 'M') + p.x + ',' + p.y).join(' ');
+};

--- a/lib/features/hierarchy/HierarchyStyles.js
+++ b/lib/features/hierarchy/HierarchyStyles.js
@@ -1,0 +1,13 @@
+export default function HierarchyStyles() {}
+
+HierarchyStyles.prototype.getNodeStyle = function(node) {
+  const strokeBySex = {
+    'M': '#3498db',
+    'F': '#e74c3c'
+  };
+
+  const stroke = strokeBySex[node.sex] || '#34495e';
+  const fill = node.status === 'dead' ? '#f9f9f9' : '#ffffff';
+
+  return { stroke, fill };
+};

--- a/lib/features/hierarchy/demo.js
+++ b/lib/features/hierarchy/demo.js
@@ -1,0 +1,15 @@
+import Diagram from '../../Diagram';
+import HierarchyModule from './index';
+import data from './sampleData';
+
+const canvasEl = document.querySelector('#canvas');
+
+const diagram = new Diagram({
+  canvas: { container: canvasEl },
+  modules: [ HierarchyModule ]
+});
+
+diagram.get('hierarchyModeling').load(data);
+
+// expose for console use
+window.diagram = diagram;

--- a/lib/features/hierarchy/index.js
+++ b/lib/features/hierarchy/index.js
@@ -1,0 +1,24 @@
+import MoveModule from '../move';
+import InteractionEventsModule from '../interaction-events';
+import ModelingModule from '../modeling';
+
+import HierarchyRenderer from './HierarchyRenderer';
+import HierarchyModeling from './HierarchyModeling';
+import HierarchyLayout from './HierarchyLayout';
+import HierarchyStyles from './HierarchyStyles';
+
+/**
+ * @type { import('didi').ModuleDeclaration }
+ */
+export default {
+  __depends__: [
+    MoveModule,
+    InteractionEventsModule,
+    ModelingModule
+  ],
+  __init__: [ 'hierarchyModeling', 'hierarchyRenderer' ],
+  hierarchyModeling: [ 'type', HierarchyModeling ],
+  hierarchyRenderer: [ 'type', HierarchyRenderer ],
+  hierarchyLayout: [ 'type', HierarchyLayout ],
+  hierarchyStyles: [ 'type', HierarchyStyles ]
+};

--- a/lib/features/hierarchy/sampleData.js
+++ b/lib/features/hierarchy/sampleData.js
@@ -1,0 +1,13 @@
+export default {
+  nodes: [
+    { id: 'n1', label: 'Имя 1', sex: 'M', status: 'alive' },
+    { id: 'n2', label: 'Имя 2', sex: 'F', status: 'alive' },
+    { id: 'n3', label: 'Имя 3', sex: 'M', status: 'dead' },
+    { id: 'n4', label: 'Имя 4', sex: 'F', status: 'alive' }
+  ],
+  edges: [
+    { source: 'n1', target: 'n2' },
+    { source: 'n1', target: 'n3' },
+    { source: 'n2', target: 'n4' }
+  ]
+};


### PR DESCRIPTION
## Summary
- implement hierarchy visualization module with modeling, renderer, layout, and styles
- include sample data and demo setup
- document example usage in README

## Testing
- `npm run lint` *(fails: cannot find eslint-plugin-bpmn-io)*
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d660fef948331bb7a364ce1d61529