### PR TITLE
Add webpack demo environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lib/**/*.d.ts
 .DS_Store
 .*.swp
 .*.swo
+demo/bundle.js

--- a/README.md
+++ b/README.md
@@ -75,7 +75,15 @@ const diagram = new Diagram({
 diagram.get("hierarchyModeling").load(data);
 ```
 
+## Run demo locally
 
+Start the webpack development server to experiment with the included example:
+
+```sh
+npm start
+```
+
+Open http://localhost:8080 in your browser to view the demo.
 
 ## License
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,0 +1,15 @@
+import Diagram from '../lib/Diagram';
+import HierarchyModule from '../lib/features/hierarchy';
+import data from '../lib/features/hierarchy/sampleData';
+
+const canvas = document.querySelector('#canvas');
+
+const diagram = new Diagram({
+  canvas: { container: canvas },
+  modules: [ HierarchyModule ]
+});
+
+diagram.get('hierarchyModeling').load(data);
+
+// expose for console debugging
+window.diagram = diagram;

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>diagram-js demo</title>
+  <style>
+    html, body, #canvas {
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+<body>
+  <div id="canvas"></div>
+  <script src="bundle.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "generate-types:generate": "del-cli \"lib/**/*.d.ts\" && npx bio-dts -r lib",
     "generate-types:test": "tsc --noEmit --noImplicitAny",
     "test": "karma start",
+    "start": "webpack serve --config webpack.config.js",
     "prepublishOnly": "run-s generate-types"
   },
   "repository": {
@@ -77,7 +78,9 @@
     "sinon": "^17.0.1",
     "sinon-chai": "^3.7.0",
     "typescript": "^5.7.3",
-    "webpack": "^5.95.0"
+    "webpack": "^5.95.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
     "@bpmn-io/diagram-js-ui": "^0.2.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,34 @@
+const path = require('path');
+
+module.exports = {
+  mode: 'development',
+  entry: './demo/app.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'demo')
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'demo')
+    },
+    port: 8080,
+    open: true
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'asset/source'
+      },
+      {
+        test: /\.png$/,
+        type: 'asset/resource'
+      }
+    ]
+  },
+  resolve: {
+    mainFields: [ 'dev:module', 'module', 'main' ],
+    modules: [ 'node_modules', path.resolve(__dirname) ]
+  },
+  devtool: 'source-map'
+};


### PR DESCRIPTION
## Summary
- create a demo folder with a basic example
- add webpack configuration and ignore built bundle
- add start script and dev dependencies
- document how to run the demo

## Testing
- `npm test` *(fails: karma not found)*
- `npm run lint` *(fails: cannot find eslint-plugin-bpmn-io)*

------
https://chatgpt.com/codex/tasks/task_b_683d6c035d0c83319af921eb70aefeb2