### PR TITLE
Add hierarchy demo with panning and details panel

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -1,15 +1,29 @@
 import Diagram from '../lib/Diagram';
 import HierarchyModule from '../lib/features/hierarchy';
+import MoveCanvasModule from '../lib/navigation/movecanvas';
+import ZoomScrollModule from '../lib/navigation/zoomscroll';
 import data from '../lib/features/hierarchy/sampleData';
 
 const canvas = document.querySelector('#canvas');
 
 const diagram = new Diagram({
   canvas: { container: canvas },
-  modules: [ HierarchyModule ]
+  modules: [ MoveCanvasModule, ZoomScrollModule, HierarchyModule ]
 });
 
 diagram.get('hierarchyModeling').load(data);
+
+// show element details on click
+const detailsPanel = document.querySelector('#details');
+diagram.get('eventBus').on('element.click', ({ element }) => {
+  const bo = element.businessObject || {};
+  detailsPanel.innerHTML = `
+    <h3>${bo.label || ''}</h3>
+    <p>Status: ${bo.status || ''}</p>
+    <p>Sex: ${bo.sex || ''}</p>
+    <p>ID: ${element.id}</p>
+  `;
+});
 
 // expose for console debugging
 window.diagram = diagram;

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,15 @@
   </style>
 </head>
 <body>
-  <div id="canvas"></div>
+  <div id="canvas" style="height:100%;"></div>
+  <div id="legend" style="position:absolute; top:10px; right:10px; background:#fff; border:1px solid #ccc; padding:10px; font-family:sans-serif;">
+    <h4>Legend</h4>
+    <div class="item"><span class="box" style="border-color:#3498db; border-width:2px; border-style:solid; display:inline-block; width:12px; height:12px; margin-right:4px;"></span> Male</div>
+    <div class="item"><span class="box" style="border-color:#e74c3c; border-width:2px; border-style:solid; display:inline-block; width:12px; height:12px; margin-right:4px;"></span> Female</div>
+    <div class="item"><span class="box" style="background:#ffffff; border:2px solid #ccc; display:inline-block; width:12px; height:12px; margin-right:4px;"></span> Alive</div>
+    <div class="item"><span class="box" style="background:#f9f9f9; border:2px solid #ccc; display:inline-block; width:12px; height:12px; margin-right:4px;"></span> Dead</div>
+  </div>
+  <div id="details" style="position:absolute; bottom:10px; right:10px; background:#fff; border:1px solid #ccc; padding:10px; font-family:sans-serif; width:200px;"></div>
   <script src="bundle.js"></script>
 </body>
 </html>

--- a/lib/features/hierarchy/HierarchyModeling.js
+++ b/lib/features/hierarchy/HierarchyModeling.js
@@ -13,9 +13,13 @@ HierarchyModeling.prototype.load = function(data) {
   const edges = [];
 
   data.nodes.forEach(n => {
+    const position = {
+      x: typeof n.x === 'number' ? n.x : 100,
+      y: typeof n.y === 'number' ? n.y : 100
+    };
     const shape = this._modeling.createShape(
       { id: n.id, width: 150, height: 70, type: 'hierarchy:node', businessObject: n },
-      { x: 0, y: 0 },
+      position,
       root
     );
     nodes[n.id] = shape;


### PR DESCRIPTION
## Summary
- show a legend and details panel in the demo page
- enable canvas panning/zooming in the demo
- display element details on click
- guard against missing coordinates when creating nodes

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d6f08f1408331928d5e577416d65a