### PR TITLE
Add auto layout and expand hierarchy demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,66 @@ Use it as follows:
 
 ```javascript
 import Diagram from "diagram-js/lib/Diagram";
+import autoLayout from "diagram-js/lib/features/hierarchy/autoLayout";
 import HierarchyModule from "diagram-js/lib/features/hierarchy";
+import data from "diagram-js/lib/features/hierarchy/sampleData";
+
+import MoveCanvasModule from "diagram-js/lib/navigation/movecanvas";
+import ZoomScrollModule from "diagram-js/lib/navigation/zoomscroll";
+
+import ConnectModule from "diagram-js/lib/features/connect";
+import ContextPadModule from "diagram-js/lib/features/context-pad";
+import CreateModule from "diagram-js/lib/features/create";
+import HandToolModule from "diagram-js/lib/features/hand-tool";
+import LassoToolModule from "diagram-js/lib/features/lasso-tool";
+import SpaceToolModule from "diagram-js/lib/features/space-tool";
+import GlobalConnectModule from "diagram-js/lib/features/global-connect";
+import ModelingModule from "diagram-js/lib/features/modeling";
+import MoveModule from "diagram-js/lib/features/move";
+import OutlineModule from "diagram-js/lib/features/outline";
+import PaletteModule from "diagram-js/lib/features/palette";
+import ResizeModule from "diagram-js/lib/features/resize";
+import RulesModule from "diagram-js/lib/features/rules";
+import SelectionModule from "diagram-js/lib/features/selection";
+import LabelSupportModule from "diagram-js/lib/features/label-support";
+import PopupMenuModule from "diagram-js/lib/features/popup-menu";
+import OverlaysModule from "diagram-js/lib/features/overlays";
+import TranslateModule from "diagram-js/lib/i18n/translate";
+import SnappingModule from "diagram-js/lib/features/snapping";
+import EditorActionsModule from "diagram-js/lib/features/editor-actions";
+import KeyboardModule from "diagram-js/lib/features/keyboard";
 
 const diagram = new Diagram({
   canvas: { container: document.querySelector("#canvas") },
-  modules: [ HierarchyModule ]
+  modules: [
+    MoveCanvasModule,
+    ZoomScrollModule,
+    ConnectModule,
+    ContextPadModule,
+    CreateModule,
+    HandToolModule,
+    LassoToolModule,
+    SpaceToolModule,
+    GlobalConnectModule,
+    ModelingModule,
+    MoveModule,
+    OutlineModule,
+    PaletteModule,
+    ResizeModule,
+    RulesModule,
+    SelectionModule,
+    LabelSupportModule,
+    PopupMenuModule,
+    OverlaysModule,
+    TranslateModule,
+    SnappingModule,
+    EditorActionsModule,
+    KeyboardModule,
+    HierarchyModule
+  ]
 });
 
+autoLayout(data);
 diagram.get("hierarchyModeling").load(data);
 ```
 

--- a/demo/app.js
+++ b/demo/app.js
@@ -2,15 +2,64 @@ import Diagram from '../lib/Diagram';
 import HierarchyModule from '../lib/features/hierarchy';
 import MoveCanvasModule from '../lib/navigation/movecanvas';
 import ZoomScrollModule from '../lib/navigation/zoomscroll';
+
+import ConnectModule from '../lib/features/connect';
+import ContextPadModule from '../lib/features/context-pad';
+import CreateModule from '../lib/features/create';
+import HandToolModule from '../lib/features/hand-tool';
+import LassoToolModule from '../lib/features/lasso-tool';
+import SpaceToolModule from '../lib/features/space-tool';
+import GlobalConnectModule from '../lib/features/global-connect';
+import ModelingModule from '../lib/features/modeling';
+import MoveModule from '../lib/features/move';
+import OutlineModule from '../lib/features/outline';
+import PaletteModule from '../lib/features/palette';
+import ResizeModule from '../lib/features/resize';
+import RulesModule from '../lib/features/rules';
+import SelectionModule from '../lib/features/selection';
+import LabelSupportModule from '../lib/features/label-support';
+import PopupMenuModule from '../lib/features/popup-menu';
+import OverlaysModule from '../lib/features/overlays';
+import TranslateModule from '../lib/i18n/translate';
+import SnappingModule from '../lib/features/snapping';
+import EditorActionsModule from '../lib/features/editor-actions';
+import KeyboardModule from '../lib/features/keyboard';
 import data from '../lib/features/hierarchy/sampleData';
+import autoLayout from '../lib/features/hierarchy/autoLayout';
 
 const canvas = document.querySelector('#canvas');
 
 const diagram = new Diagram({
   canvas: { container: canvas },
-  modules: [ MoveCanvasModule, ZoomScrollModule, HierarchyModule ]
+  modules: [
+    MoveCanvasModule,
+    ZoomScrollModule,
+    ConnectModule,
+    ContextPadModule,
+    CreateModule,
+    HandToolModule,
+    LassoToolModule,
+    SpaceToolModule,
+    GlobalConnectModule,
+    ModelingModule,
+    MoveModule,
+    OutlineModule,
+    PaletteModule,
+    ResizeModule,
+    RulesModule,
+    SelectionModule,
+    LabelSupportModule,
+    PopupMenuModule,
+    OverlaysModule,
+    TranslateModule,
+    SnappingModule,
+    EditorActionsModule,
+    KeyboardModule,
+    HierarchyModule
+  ]
 });
 
+autoLayout(data);
 diagram.get('hierarchyModeling').load(data);
 
 // show element details on click

--- a/lib/features/hierarchy/HierarchyModeling.js
+++ b/lib/features/hierarchy/HierarchyModeling.js
@@ -1,3 +1,5 @@
+import autoLayout from './autoLayout';
+
 export default function HierarchyModeling(canvas, modeling, eventBus, hierarchyLayout) {
   this._canvas = canvas;
   this._modeling = modeling;
@@ -8,6 +10,9 @@ export default function HierarchyModeling(canvas, modeling, eventBus, hierarchyL
 HierarchyModeling.$inject = [ 'canvas', 'modeling', 'eventBus', 'hierarchyLayout' ];
 
 HierarchyModeling.prototype.load = function(data) {
+  // ensure nodes have coordinates via auto layout
+  autoLayout(data);
+
   const root = this._canvas.getRootElement();
   const nodes = {};
   const edges = [];

--- a/lib/features/hierarchy/autoLayout.js
+++ b/lib/features/hierarchy/autoLayout.js
@@ -1,0 +1,40 @@
+export default function autoLayout(data) {
+  const spacingX = 200;
+  const spacingY = 120;
+  const positioned = {};
+  const levelMap = {};
+
+  const rootId = data.nodes[0] && data.nodes[0].id;
+  if (!rootId) {
+    return data;
+  }
+
+  function assignLevels(id, level = 0) {
+    if (!levelMap[level]) levelMap[level] = [];
+    if (!positioned[id]) {
+      positioned[id] = { id, level };
+      levelMap[level].push(id);
+
+      const children = data.edges
+        .filter(e => e.source === id)
+        .map(e => e.target);
+      children.forEach(childId => assignLevels(childId, level + 1));
+    }
+  }
+
+  assignLevels(rootId);
+
+  data.nodes.forEach(node => {
+    const info = positioned[node.id] || { level: 0 };
+    const index = levelMap[info.level].indexOf(node.id);
+
+    if (typeof node.x !== 'number') {
+      node.x = index * spacingX;
+    }
+    if (typeof node.y !== 'number') {
+      node.y = info.level * spacingY;
+    }
+  });
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- add `autoLayout` utility to compute coordinates when missing
- use `autoLayout` in `HierarchyModeling.load`
- enhance hierarchy demo with many interaction modules and auto layout
- document the new setup in the README

## Testing
- `npm test` *(fails: `karma` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d771220808331a0a2bfb14463346f