### PR TITLE
Add context pad and connection display

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -511,6 +511,12 @@
   background: var(--context-pad-entry-hover-background-color);
 }
 
+.djs-context-pad .log-entry:after {
+  content: 'L';
+  font-size: 14px;
+  line-height: 22px;
+}
+
 .djs-context-pad.open {
   display: block;
 }

--- a/demo/app.js
+++ b/demo/app.js
@@ -14,7 +14,6 @@ import ModelingModule from '../lib/features/modeling';
 import MoveModule from '../lib/features/move';
 import OutlineModule from '../lib/features/outline';
 import PaletteModule from '../lib/features/palette';
-import ResizeModule from '../lib/features/resize';
 import RulesModule from '../lib/features/rules';
 import SelectionModule from '../lib/features/selection';
 import LabelSupportModule from '../lib/features/label-support';
@@ -25,7 +24,6 @@ import SnappingModule from '../lib/features/snapping';
 import EditorActionsModule from '../lib/features/editor-actions';
 import KeyboardModule from '../lib/features/keyboard';
 import data from '../lib/features/hierarchy/sampleData';
-import autoLayout from '../lib/features/hierarchy/autoLayout';
 
 const canvas = document.querySelector('#canvas');
 
@@ -45,7 +43,6 @@ const diagram = new Diagram({
     MoveModule,
     OutlineModule,
     PaletteModule,
-    ResizeModule,
     RulesModule,
     SelectionModule,
     LabelSupportModule,
@@ -59,7 +56,6 @@ const diagram = new Diagram({
   ]
 });
 
-autoLayout(data);
 diagram.get('hierarchyModeling').load(data);
 
 // show element details on click
@@ -76,3 +72,17 @@ diagram.get('eventBus').on('element.click', ({ element }) => {
 
 // expose for console debugging
 window.diagram = diagram;
+
+const saveBtn = document.querySelector('#save');
+saveBtn.addEventListener('click', () => {
+  const data = diagram.get('hierarchyModeling').save();
+  const blob = new Blob([ JSON.stringify(data, null, 2) ], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'diagram.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+});

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,6 +21,7 @@
     <div class="item"><span class="box" style="background:#f9f9f9; border:2px solid #ccc; display:inline-block; width:12px; height:12px; margin-right:4px;"></span> Dead</div>
   </div>
   <div id="details" style="position:absolute; bottom:10px; right:10px; background:#fff; border:1px solid #ccc; padding:10px; font-family:sans-serif; width:200px;"></div>
+  <button id="save" style="position:absolute; top:10px; left:10px; z-index:10;">Save JSON</button>
   <script src="bundle.js"></script>
 </body>
 </html>

--- a/lib/features/hierarchy/HierarchyContextPadProvider.js
+++ b/lib/features/hierarchy/HierarchyContextPadProvider.js
@@ -1,0 +1,26 @@
+export default function HierarchyContextPadProvider(contextPad) {
+  this._contextPad = contextPad;
+
+  contextPad.registerProvider(this);
+}
+
+HierarchyContextPadProvider.$inject = ['contextPad'];
+
+HierarchyContextPadProvider.prototype.getContextPadEntries = function(element) {
+  if (element.type !== 'hierarchy:node') {
+    return {};
+  }
+
+  return {
+    log: {
+      className: 'log-entry',
+      title: 'Log element',
+      action: {
+        click: function() {
+          // log element to console
+          console.log('context pad clicked for', element.id);
+        }
+      }
+    }
+  };
+};

--- a/lib/features/hierarchy/HierarchyModeling.js
+++ b/lib/features/hierarchy/HierarchyModeling.js
@@ -34,7 +34,7 @@ HierarchyModeling.prototype.load = function(data) {
     const connection = this._modeling.createConnection(
       nodes[e.source],
       nodes[e.target],
-      { id: e.source + '-' + e.target, type: 'hierarchy:edge', waypoints: [] },
+      { id: e.source + '-' + e.target, type: 'hierarchy:edge', waypoints: [], businessObject: e },
       root
     );
     edges.push({ data: e, connection });
@@ -51,4 +51,29 @@ HierarchyModeling.prototype.load = function(data) {
 HierarchyModeling.prototype.layout = function() {
   this._hierarchyLayout.layout(Object.values(this._nodes), this._edges);
   this._eventBus.fire('hierarchy.layouted');
+};
+
+HierarchyModeling.prototype.save = function() {
+  const nodes = Object.values(this._nodes).map(n => {
+    const bo = n.businessObject || {};
+    return {
+      id: n.id,
+      label: bo.label,
+      sex: bo.sex,
+      status: bo.status,
+      x: n.x,
+      y: n.y
+    };
+  });
+
+  const edges = this._edges.map(e => {
+    const bo = e.connection.businessObject || {};
+    return {
+      source: e.connection.source.id,
+      target: e.connection.target.id,
+      label: bo.label
+    };
+  });
+
+  return { nodes, edges };
 };

--- a/lib/features/hierarchy/HierarchyRenderer.js
+++ b/lib/features/hierarchy/HierarchyRenderer.js
@@ -1,6 +1,12 @@
 import inherits from 'inherits-browser';
 import BaseRenderer from '../../draw/BaseRenderer';
-import { append as svgAppend, attr as svgAttr, create as svgCreate } from 'tiny-svg';
+import {
+  append as svgAppend,
+  attr as svgAttr,
+  create as svgCreate
+} from 'tiny-svg';
+
+import { getConnectionMid } from '../../layout/LayoutUtil';
 
 const HIGH_PRIORITY = 1500;
 
@@ -8,6 +14,11 @@ export default function HierarchyRenderer(eventBus, styles, hierarchyStyles) {
   BaseRenderer.call(this, eventBus, HIGH_PRIORITY);
   this._styles = styles;
   this._hierarchyStyles = hierarchyStyles;
+  this._eventBus = eventBus;
+
+  eventBus.on('canvas.init', ({ svg }) => {
+    this._ensureMarker(svg);
+  });
 }
 
 inherits(HierarchyRenderer, BaseRenderer);
@@ -52,9 +63,20 @@ HierarchyRenderer.prototype.drawConnection = function(parent, connection) {
     d: path,
     stroke: '#555',
     strokeWidth: 1.5,
-    fill: 'none'
+    fill: 'none',
+    markerEnd: 'url(#connection-arrow)'
   });
   svgAppend(parent, line);
+
+  const bo = connection.businessObject || {};
+  if (bo.label) {
+    const mid = getConnectionMid(connection);
+    const text = svgCreate('text');
+    svgAttr(text, { x: mid.x, y: mid.y - 5, 'font-size': '12', 'text-anchor': 'middle' });
+    text.textContent = bo.label;
+    svgAppend(parent, text);
+  }
+
   return line;
 };
 
@@ -70,4 +92,34 @@ HierarchyRenderer.prototype.getShapePath = function(shape) {
 
 HierarchyRenderer.prototype.getConnectionPath = function(connection) {
   return connection.waypoints.map((p, i) => (i ? 'L' : 'M') + p.x + ',' + p.y).join(' ');
+};
+
+HierarchyRenderer.prototype._ensureMarker = function(svg) {
+  if (this._markerCreated) {
+    return;
+  }
+
+  let defs = svg.querySelector('defs');
+  if (!defs) {
+    defs = svgCreate('defs');
+    svgAppend(svg, defs);
+  }
+
+  const marker = svgCreate('marker');
+  svgAttr(marker, {
+    id: 'connection-arrow',
+    viewBox: '0 0 10 10',
+    refX: 10,
+    refY: 5,
+    markerWidth: 10,
+    markerHeight: 10,
+    orient: 'auto'
+  });
+
+  const path = svgCreate('path');
+  svgAttr(path, { d: 'M 0 0 L 10 5 L 0 10 z', fill: '#555' });
+  svgAppend(marker, path);
+  svgAppend(defs, marker);
+
+  this._markerCreated = true;
 };

--- a/lib/features/hierarchy/index.js
+++ b/lib/features/hierarchy/index.js
@@ -6,6 +6,7 @@ import HierarchyRenderer from './HierarchyRenderer';
 import HierarchyModeling from './HierarchyModeling';
 import HierarchyLayout from './HierarchyLayout';
 import HierarchyStyles from './HierarchyStyles';
+import HierarchyContextPadProvider from './HierarchyContextPadProvider';
 
 /**
  * @type { import('didi').ModuleDeclaration }
@@ -16,9 +17,10 @@ export default {
     InteractionEventsModule,
     ModelingModule
   ],
-  __init__: [ 'hierarchyModeling', 'hierarchyRenderer' ],
+  __init__: [ 'hierarchyModeling', 'hierarchyRenderer', 'hierarchyContextPadProvider' ],
   hierarchyModeling: [ 'type', HierarchyModeling ],
   hierarchyRenderer: [ 'type', HierarchyRenderer ],
   hierarchyLayout: [ 'type', HierarchyLayout ],
-  hierarchyStyles: [ 'type', HierarchyStyles ]
+  hierarchyStyles: [ 'type', HierarchyStyles ],
+  hierarchyContextPadProvider: [ 'type', HierarchyContextPadProvider ]
 };

--- a/lib/features/hierarchy/sampleData.js
+++ b/lib/features/hierarchy/sampleData.js
@@ -6,8 +6,8 @@ export default {
     { id: 'n4', label: 'Имя 4', sex: 'F', status: 'alive' }
   ],
   edges: [
-    { source: 'n1', target: 'n2' },
-    { source: 'n1', target: 'n3' },
-    { source: 'n2', target: 'n4' }
+    { source: 'n1', target: 'n2', label: 'связь 1-2' },
+    { source: 'n1', target: 'n3', label: 'связь 1-3' },
+    { source: 'n2', target: 'n4', label: 'связь 2-4' }
   ]
 };


### PR DESCRIPTION
## Summary
- show connection arrows and labels in hierarchy renderer
- support saving hierarchy data to JSON
- provide context pad with console action
- add save JSON button to the demo
- disable resize module

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d7c0f05348331b7d6db9ce6e38eb8