### PR TITLE
Fix hierarchy connection waypoints and enable context pad

### DIFF
--- a/lib/features/hierarchy/HierarchyModeling.js
+++ b/lib/features/hierarchy/HierarchyModeling.js
@@ -34,7 +34,7 @@ HierarchyModeling.prototype.load = function(data) {
     const connection = this._modeling.createConnection(
       nodes[e.source],
       nodes[e.target],
-      { id: e.source + '-' + e.target, type: 'hierarchy:edge', waypoints: [], businessObject: e },
+      { id: e.source + '-' + e.target, type: 'hierarchy:edge', businessObject: e },
       root
     );
     edges.push({ data: e, connection });

--- a/lib/features/hierarchy/index.js
+++ b/lib/features/hierarchy/index.js
@@ -1,6 +1,7 @@
 import MoveModule from '../move';
 import InteractionEventsModule from '../interaction-events';
 import ModelingModule from '../modeling';
+import ContextPadModule from '../context-pad';
 
 import HierarchyRenderer from './HierarchyRenderer';
 import HierarchyModeling from './HierarchyModeling';
@@ -15,7 +16,8 @@ export default {
   __depends__: [
     MoveModule,
     InteractionEventsModule,
-    ModelingModule
+    ModelingModule,
+    ContextPadModule
   ],
   __init__: [ 'hierarchyModeling', 'hierarchyRenderer', 'hierarchyContextPadProvider' ],
   hierarchyModeling: [ 'type', HierarchyModeling ],


### PR DESCRIPTION
## Summary
- ensure hierarchy connections have initial waypoints
- enable context pad functionality for hierarchy demo

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d833243788331bd3807a06845e45e