### PR TITLE
Implement horizontal hierarchy layout with child creation

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -517,6 +517,12 @@
   line-height: 22px;
 }
 
+.djs-context-pad .add-child-entry:after {
+  content: '+';
+  font-size: 14px;
+  line-height: 22px;
+}
+
 .djs-context-pad.open {
   display: block;
 }

--- a/lib/features/hierarchy/HierarchyContextPadProvider.js
+++ b/lib/features/hierarchy/HierarchyContextPadProvider.js
@@ -1,15 +1,18 @@
-export default function HierarchyContextPadProvider(contextPad) {
+export default function HierarchyContextPadProvider(contextPad, hierarchyModeling) {
   this._contextPad = contextPad;
+  this._hierarchyModeling = hierarchyModeling;
 
   contextPad.registerProvider(this);
 }
 
-HierarchyContextPadProvider.$inject = ['contextPad'];
+HierarchyContextPadProvider.$inject = ['contextPad', 'hierarchyModeling'];
 
 HierarchyContextPadProvider.prototype.getContextPadEntries = function(element) {
   if (element.type !== 'hierarchy:node') {
     return {};
   }
+
+  const self = this;
 
   return {
     log: {
@@ -17,8 +20,16 @@ HierarchyContextPadProvider.prototype.getContextPadEntries = function(element) {
       title: 'Log element',
       action: {
         click: function() {
-          // log element to console
           console.log('context pad clicked for', element.id);
+        }
+      }
+    },
+    add: {
+      className: 'add-child-entry',
+      title: 'Add child',
+      action: {
+        click: function() {
+          self._hierarchyModeling.addChild(element);
         }
       }
     }

--- a/lib/features/hierarchy/HierarchyLayout.js
+++ b/lib/features/hierarchy/HierarchyLayout.js
@@ -1,3 +1,5 @@
+import { connectRectangles } from '../../layout/ManhattanLayout';
+
 export default function HierarchyLayout(modeling) {
   this._modeling = modeling;
 }
@@ -18,8 +20,8 @@ HierarchyLayout.prototype.layout = function(nodes, edges) {
   const rootNodes = nodes.filter(n => !edges.some(e => e.connection.target === n));
 
   const positionNode = (node, depth, index) => {
-    const x = index * levelWidth;
-    const y = depth * levelHeight;
+    const x = depth * levelWidth;
+    const y = index * levelHeight;
     const delta = { x: x - (node.x || 0), y: y - (node.y || 0) };
     this._modeling.moveShape(node, delta);
 
@@ -32,10 +34,15 @@ HierarchyLayout.prototype.layout = function(nodes, edges) {
   edges.forEach(e => {
     const s = e.connection.source;
     const t = e.connection.target;
-    const waypoints = [
-      { x: s.x + s.width / 2, y: s.y + s.height },
-      { x: t.x + t.width / 2, y: t.y }
-    ];
+
+    const waypoints = connectRectangles(
+      { x: s.x, y: s.y, width: s.width, height: s.height },
+      { x: t.x, y: t.y, width: t.width, height: t.height },
+      { x: s.x + s.width, y: s.y + s.height / 2 },
+      { x: t.x, y: t.y + t.height / 2 },
+      { preferredLayouts: [ 'h:h' ] }
+    );
+
     this._modeling.updateWaypoints(e.connection, waypoints);
   });
 };

--- a/lib/features/hierarchy/HierarchyModeling.js
+++ b/lib/features/hierarchy/HierarchyModeling.js
@@ -77,3 +77,38 @@ HierarchyModeling.prototype.save = function() {
 
   return { nodes, edges };
 };
+
+HierarchyModeling.prototype.addChild = function(parent) {
+  const idx = Object.keys(this._nodes).length + 1;
+  const id = parent.id + '_child_' + idx;
+
+  const data = { id, label: 'Child ' + idx };
+
+  const shape = this._modeling.createShape(
+    { id, width: 150, height: 70, type: 'hierarchy:node', businessObject: data },
+    { x: parent.x + parent.width + 50, y: parent.y },
+    parent.parent || this._canvas.getRootElement()
+  );
+
+  this._nodes[id] = shape;
+
+  const connection = this._modeling.createConnection(
+    parent,
+    shape,
+    { id: parent.id + '-' + id, type: 'hierarchy:edge', businessObject: { source: parent.id, target: id } },
+    parent.parent || this._canvas.getRootElement()
+  );
+
+  this._edges.push({ data: { source: parent.id, target: id }, connection });
+
+  const children = parent.children.filter(c => c.type === 'hierarchy:node');
+  const requiredHeight = Math.max(parent.height, children.length * 80);
+  this._modeling.resizeShape(parent, {
+    x: parent.x,
+    y: parent.y,
+    width: parent.width,
+    height: requiredHeight
+  });
+
+  this.layout();
+};


### PR DESCRIPTION
## Summary
- layout hierarchy left-to-right using Manhattan connection routing
- add context pad entry to create child nodes
- enlarge parent nodes when new children are added
- style add-child context pad entry

## Testing
- `npm test` *(fails: karma not found)*
- `npm run lint` *(fails: cannot find eslint-plugin-bpmn-io)*

------
https://chatgpt.com/codex/tasks/task_b_683d864eb2b483319c3a1d29382d111d