### PR TITLE
Improve layout labels and context pad

### DIFF
--- a/assets/diagram-js.css
+++ b/assets/diagram-js.css
@@ -522,6 +522,11 @@
   font-size: 14px;
   line-height: 22px;
 }
+.djs-context-pad .info-entry:after {
+  content: 'i';
+  font-size: 14px;
+  line-height: 22px;
+}
 
 .djs-context-pad.open {
   display: block;

--- a/lib/features/hierarchy/HierarchyContextPadProvider.js
+++ b/lib/features/hierarchy/HierarchyContextPadProvider.js
@@ -32,6 +32,15 @@ HierarchyContextPadProvider.prototype.getContextPadEntries = function(element) {
           self._hierarchyModeling.addChild(element);
         }
       }
+    },
+    info: {
+      className: 'info-entry',
+      title: 'Show info',
+      action: {
+        click: function() {
+          console.log('info for', element.id);
+        }
+      }
     }
   };
 };

--- a/lib/features/hierarchy/HierarchyRenderer.js
+++ b/lib/features/hierarchy/HierarchyRenderer.js
@@ -7,6 +7,7 @@ import {
 } from 'tiny-svg';
 
 import { getConnectionMid } from '../../layout/LayoutUtil';
+import Text from '../../util/Text';
 
 const HIGH_PRIORITY = 1500;
 
@@ -15,6 +16,7 @@ export default function HierarchyRenderer(eventBus, styles, hierarchyStyles) {
   this._styles = styles;
   this._hierarchyStyles = hierarchyStyles;
   this._eventBus = eventBus;
+  this._textUtil = new Text();
 
   eventBus.on('canvas.init', ({ svg }) => {
     this._ensureMarker(svg);
@@ -71,9 +73,17 @@ HierarchyRenderer.prototype.drawConnection = function(parent, connection) {
   const bo = connection.businessObject || {};
   if (bo.label) {
     const mid = getConnectionMid(connection);
-    const text = svgCreate('text');
-    svgAttr(text, { x: mid.x, y: mid.y - 5, 'font-size': '12', 'text-anchor': 'middle' });
-    text.textContent = bo.label;
+    const start = connection.waypoints[0];
+    const end = connection.waypoints[connection.waypoints.length - 1];
+    const width = Math.abs(end.x - start.x) - 10;
+
+    const layout = this._textUtil.layoutText(bo.label, { box: { width, height: 40 }, fitBox: true });
+
+    const text = layout.element;
+    svgAttr(text, {
+      transform: 'translate(' + (mid.x - layout.dimensions.width / 2) + ',' + (mid.y - layout.dimensions.height / 2 - 5) + ')',
+      'font-size': '12'
+    });
     svgAppend(parent, text);
   }
 

--- a/lib/features/hierarchy/autoLayout.js
+++ b/lib/features/hierarchy/autoLayout.js
@@ -1,5 +1,19 @@
+import Text from '../../util/Text';
+
 export default function autoLayout(data) {
-  const spacingX = 200;
+  const textUtil = new Text();
+
+  let maxLabelWidth = 0;
+  data.edges.forEach(e => {
+    if (e.label) {
+      const dim = textUtil.getDimensions(e.label, { box: { width: 1000, height: 50 } });
+      if (dim.width > maxLabelWidth) {
+        maxLabelWidth = dim.width;
+      }
+    }
+  });
+
+  const spacingX = Math.max(200, maxLabelWidth + 50);
   const spacingY = 120;
   const positioned = {};
   const levelMap = {};


### PR DESCRIPTION
## Summary
- auto-layout now considers edge label width to derive horizontal spacing
- wrap connection labels to two rows when needed
- provide `info` entry with icon in hierarchy context pad

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-bpmn-io')*
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d9420e5bc83319d1ce365933c3b5a