### PR TITLE
Add multiple auto-layouts with UI selector

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -58,6 +58,13 @@ const diagram = new Diagram({
 
 diagram.get('hierarchyModeling').load(data);
 
+const layoutSelector = document.querySelector('#layoutSelector');
+layoutSelector.addEventListener('change', e => {
+  const type = e.target.value;
+  diagram.get('hierarchyLayout').setType(type);
+  diagram.get('hierarchyModeling').layout();
+});
+
 // show element details on click
 const detailsPanel = document.querySelector('#details');
 diagram.get('eventBus').on('element.click', ({ element }) => {

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,6 +22,12 @@
   </div>
   <div id="details" style="position:absolute; bottom:10px; right:10px; background:#fff; border:1px solid #ccc; padding:10px; font-family:sans-serif; width:200px;"></div>
   <button id="save" style="position:absolute; top:10px; left:10px; z-index:10;">Save JSON</button>
+  <select id="layoutSelector" style="position:absolute; top:10px; left:100px; z-index:10;">
+    <option value="tree">Stromová struktura</option>
+    <option value="layered">Směrovaný graf</option>
+    <option value="circular">Kruhové rozmístění</option>
+    <option value="force">Síťová simulace</option>
+  </select>
   <script src="bundle.js"></script>
 </body>
 </html>

--- a/lib/features/hierarchy/HierarchyLayout.js
+++ b/lib/features/hierarchy/HierarchyLayout.js
@@ -1,35 +1,47 @@
 import { connectRectangles } from '../../layout/ManhattanLayout';
+import treeLayout from '../../layout/treeLayout.js';
+import layeredLayout from '../../layout/layeredLayout.js';
+import circularLayout from '../../layout/circularLayout.js';
+import forceLayout from '../../layout/forceLayout.js';
 
 export default function HierarchyLayout(modeling) {
   this._modeling = modeling;
+  this._type = 'tree';
 }
 
 HierarchyLayout.$inject = [ 'modeling' ];
 
+HierarchyLayout.prototype.setType = function(type) {
+  this._type = type;
+};
+
 HierarchyLayout.prototype.layout = function(nodes, edges) {
-  const levelHeight = 120;
-  const levelWidth = 200;
+  let positions;
 
-  const childrenByParent = {};
-  edges.forEach(e => {
-    const pid = e.connection.source.id;
-    const arr = childrenByParent[pid] || (childrenByParent[pid] = []);
-    arr.push(e.connection.target);
-  });
+  switch (this._type) {
+  case 'layered':
+    positions = layeredLayout(nodes, edges);
+    break;
+  case 'circular':
+    positions = circularLayout(nodes);
+    break;
+  case 'force':
+    positions = forceLayout(nodes, edges);
+    break;
+  case 'tree':
+  default:
+    positions = treeLayout(nodes, edges);
+    break;
+  }
 
-  const rootNodes = nodes.filter(n => !edges.some(e => e.connection.target === n));
-
-  const positionNode = (node, depth, index) => {
-    const x = depth * levelWidth;
-    const y = index * levelHeight;
-    const delta = { x: x - (node.x || 0), y: y - (node.y || 0) };
+  nodes.forEach(node => {
+    const pos = positions[node.id];
+    if (!pos) {
+      return;
+    }
+    const delta = { x: pos.x - (node.x || 0), y: pos.y - (node.y || 0) };
     this._modeling.moveShape(node, delta);
-
-    const children = childrenByParent[node.id] || [];
-    children.forEach((child, i) => positionNode(child, depth + 1, i));
-  };
-
-  rootNodes.forEach((node, i) => positionNode(node, 0, i));
+  });
 
   edges.forEach(e => {
     const s = e.connection.source;

--- a/lib/layout/circularLayout.js
+++ b/lib/layout/circularLayout.js
@@ -1,0 +1,14 @@
+export default function circularLayout(nodes) {
+  const radius = 250;
+  const angle = (2 * Math.PI) / nodes.length;
+  const positions = {};
+
+  nodes.forEach((n, i) => {
+    positions[n.id] = {
+      x: Math.cos(angle * i) * radius,
+      y: Math.sin(angle * i) * radius
+    };
+  });
+
+  return positions;
+}

--- a/lib/layout/forceLayout.js
+++ b/lib/layout/forceLayout.js
@@ -1,0 +1,76 @@
+export default function forceLayout(nodes, edges) {
+  const width = 500;
+  const height = 400;
+
+  const positions = {};
+  nodes.forEach(n => {
+    positions[n.id] = {
+      x: (Math.random() - 0.5) * width,
+      y: (Math.random() - 0.5) * height,
+      vx: 0,
+      vy: 0
+    };
+  });
+
+  const iterations = 200;
+  const repulsion = 5000;
+  const attraction = 0.01;
+  const restLength = 150;
+
+  const nodeIds = nodes.map(n => n.id);
+
+  for (let k = 0; k < iterations; k++) {
+    nodeIds.forEach(id => {
+      positions[id].vx = 0;
+      positions[id].vy = 0;
+    });
+
+    for (let i = 0; i < nodeIds.length; i++) {
+      for (let j = i + 1; j < nodeIds.length; j++) {
+        const a = positions[nodeIds[i]];
+        const b = positions[nodeIds[j]];
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        const dist = Math.sqrt(dx * dx + dy * dy) + 0.01;
+        const force = repulsion / (dist * dist);
+        const fx = force * dx / dist;
+        const fy = force * dy / dist;
+        a.vx -= fx;
+        a.vy -= fy;
+        b.vx += fx;
+        b.vy += fy;
+      }
+    }
+
+    edges.forEach(e => {
+      const a = positions[e.connection.source.id];
+      const b = positions[e.connection.target.id];
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) + 0.01;
+      const force = attraction * (dist - restLength);
+      const fx = force * dx / dist;
+      const fy = force * dy / dist;
+      a.vx += fx;
+      a.vy += fy;
+      b.vx -= fx;
+      b.vy -= fy;
+    });
+
+    nodeIds.forEach(id => {
+      const p = positions[id];
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vx *= 0.85;
+      p.vy *= 0.85;
+    });
+  }
+
+  const result = {};
+  nodeIds.forEach(id => {
+    const p = positions[id];
+    result[id] = { x: p.x, y: p.y };
+  });
+
+  return result;
+}

--- a/lib/layout/layeredLayout.js
+++ b/lib/layout/layeredLayout.js
@@ -1,0 +1,55 @@
+export default function layeredLayout(nodes, edges) {
+  const spacingX = 200;
+  const spacingY = 120;
+
+  const indegree = {};
+  const children = {};
+  nodes.forEach(n => indegree[n.id] = 0);
+  edges.forEach(e => {
+    const s = e.connection.source.id;
+    const t = e.connection.target.id;
+    indegree[t] = (indegree[t] || 0) + 1;
+    const arr = children[s] || (children[s] = []);
+    arr.push(t);
+  });
+
+  const queue = [];
+  const level = {};
+  nodes.forEach(n => {
+    if (!indegree[n.id]) {
+      queue.push(n.id);
+      level[n.id] = 0;
+    }
+  });
+
+  const visited = new Set(queue);
+
+  while (queue.length) {
+    const id = queue.shift();
+    const l = level[id];
+    (children[id] || []).forEach(c => {
+      if (--indegree[c] === 0 && !visited.has(c)) {
+        level[c] = l + 1;
+        visited.add(c);
+        queue.push(c);
+      }
+    });
+  }
+
+  nodes.forEach(n => {
+    if (level[n.id] === undefined) {
+      level[n.id] = 0;
+    }
+  });
+
+  const levelIndex = {};
+  const positions = {};
+  nodes.forEach(n => {
+    const l = level[n.id];
+    const idx = levelIndex[l] || 0;
+    levelIndex[l] = idx + 1;
+    positions[n.id] = { x: idx * spacingX, y: l * spacingY };
+  });
+
+  return positions;
+}

--- a/lib/layout/treeLayout.js
+++ b/lib/layout/treeLayout.js
@@ -1,0 +1,31 @@
+export default function treeLayout(nodes, edges) {
+  const spacingX = 200;
+  const spacingY = 120;
+
+  const childrenByParent = {};
+  edges.forEach(e => {
+    const source = e.connection.source.id;
+    const target = e.connection.target.id;
+    const arr = childrenByParent[source] || (childrenByParent[source] = []);
+    arr.push(target);
+  });
+
+  const targets = new Set(edges.map(e => e.connection.target.id));
+  const roots = nodes.filter(n => !targets.has(n.id));
+
+  const positions = {};
+  const levelIndex = {};
+
+  const visit = (nodeId, level) => {
+    const idx = levelIndex[level] || 0;
+    levelIndex[level] = idx + 1;
+    positions[nodeId] = { x: level * spacingX, y: idx * spacingY };
+
+    const children = childrenByParent[nodeId] || [];
+    children.forEach(childId => visit(childId, level + 1));
+  };
+
+  roots.forEach(r => visit(r.id, 0));
+
+  return positions;
+}


### PR DESCRIPTION
## Summary
- add selectable layout dropdown in the demo
- let user change layout via `HierarchyLayout.setType`
- implement tree, layered, circular and force-directed layouts
- hook dropdown to re-layout the diagram on change

## Testing
- `npm test` *(fails: karma not found)*
- `npm run lint` *(fails: eslint-plugin-bpmn-io missing)*

------
https://chatgpt.com/codex/tasks/task_b_683d990914d0833182a5d4fd7dd6465d