### PR TITLE
Implement Manhattan connection layouter

### DIFF
--- a/lib/features/modeling/index.js
+++ b/lib/features/modeling/index.js
@@ -4,7 +4,7 @@ import SelectionModule from '../selection';
 import RulesModule from '../rules';
 
 import Modeling from './Modeling';
-import BaseLayouter from '../../layout/BaseLayouter';
+import ManhattanLayouter from '../../layout/ManhattanLayouter';
 
 
 /**
@@ -19,5 +19,5 @@ export default {
   ],
   __init__: [ 'modeling' ],
   modeling: [ 'type', Modeling ],
-  layouter: [ 'type', BaseLayouter ]
+  layouter: [ 'type', ManhattanLayouter ]
 };

--- a/lib/layout/ManhattanLayouter.js
+++ b/lib/layout/ManhattanLayouter.js
@@ -1,0 +1,61 @@
+import { getMid } from './LayoutUtil';
+import { connectRectangles, repairConnection } from './ManhattanLayout';
+
+/**
+ * A layouter that uses manhattan routing for connections.
+ *
+ * @param {import('./ConnectionDocking').default} connectionDocking
+ * @param {import('../core/EventBus').default} eventBus
+ */
+export default function ManhattanLayouter(connectionDocking, eventBus) {
+  this._connectionDocking = connectionDocking;
+  this._eventBus = eventBus;
+}
+
+ManhattanLayouter.$inject = [ 'connectionDocking', 'eventBus' ];
+
+/**
+ * Layout the given connection using manhattan routing.
+ *
+ * @param {import('../core/Types').ConnectionLike} connection
+ * @param {import('./BaseLayouter').LayoutConnectionHints} [hints]
+ *
+ * @return {import('../util/Types').Point[]}
+ */
+ManhattanLayouter.prototype.layoutConnection = function(connection, hints) {
+  hints = hints || {};
+
+  const source = hints.source || connection.source;
+  const target = hints.target || connection.target;
+
+  const oldWaypoints = connection.waypoints || [];
+
+  const start = hints.connectionStart || getMid(source);
+  const end = hints.connectionEnd || getMid(target);
+
+  let newWaypoints;
+
+  if ((hints.connectionStart || hints.connectionEnd) && oldWaypoints.length) {
+    newWaypoints = repairConnection(
+      source,
+      target,
+      start,
+      end,
+      oldWaypoints,
+      {
+        connectionStart: !!hints.connectionStart,
+        connectionEnd: !!hints.connectionEnd
+      }
+    );
+  } else {
+    newWaypoints = connectRectangles(source, target, start, end, hints);
+  }
+
+  // crop waypoints based on actual connection docking
+  if (this._connectionDocking) {
+    const tempConnection = Object.assign({}, connection, { waypoints: newWaypoints });
+    newWaypoints = this._connectionDocking.getCroppedWaypoints(tempConnection, source, target);
+  }
+
+  return newWaypoints;
+};


### PR DESCRIPTION
## Summary
- add a new `ManhattanLayouter` that uses `connectRectangles` and `repairConnection`
- use the new layouter for modeling features

## Testing
- `npm test` *(fails: karma not found)*
- `npm run lint` *(fails: eslint-plugin-bpmn-io missing)*

------
https://chatgpt.com/codex/tasks/task_b_683d9eff70948331846204698682054d