### PR TITLE
Improve layout rerendering and connection labels

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -64,7 +64,8 @@ const layoutSelector = document.querySelector('#layoutSelector');
 layoutSelector.addEventListener('change', e => {
   const type = e.target.value;
   diagram.get('hierarchyLayout').setType(type);
-  diagram.get('hierarchyModeling').layout();
+  const data = diagram.get('hierarchyModeling').save();
+  diagram.get('hierarchyModeling').load(data);
 });
 
 // show element details on click

--- a/lib/features/hierarchy/HierarchyLayout.js
+++ b/lib/features/hierarchy/HierarchyLayout.js
@@ -1,4 +1,5 @@
 import { connectRectangles } from '../../layout/ManhattanLayout';
+import { getOrientation } from '../../layout/LayoutUtil';
 import treeLayout from '../../layout/treeLayout.js';
 import layeredLayout from '../../layout/layeredLayout.js';
 import circularLayout from '../../layout/circularLayout.js';
@@ -47,12 +48,21 @@ HierarchyLayout.prototype.layout = function(nodes, edges) {
     const s = e.connection.source;
     const t = e.connection.target;
 
+    const sourceRect = { x: s.x, y: s.y, width: s.width, height: s.height };
+    const targetRect = { x: t.x, y: t.y, width: t.width, height: t.height };
+
+    const orientation = getOrientation(targetRect, sourceRect, 0);
+    let layout = 'h:h';
+    if (/top|bottom/.test(orientation)) {
+      layout = 'v:v';
+    }
+
     const waypoints = connectRectangles(
-      { x: s.x, y: s.y, width: s.width, height: s.height },
-      { x: t.x, y: t.y, width: t.width, height: t.height },
-      { x: s.x + s.width, y: s.y + s.height / 2 },
-      { x: t.x, y: t.y + t.height / 2 },
-      { preferredLayouts: [ 'h:h' ] }
+      sourceRect,
+      targetRect,
+      null,
+      null,
+      { preferredLayouts: [ layout ] }
     );
 
     this._modeling.updateWaypoints(e.connection, waypoints);

--- a/lib/features/hierarchy/HierarchyModeling.js
+++ b/lib/features/hierarchy/HierarchyModeling.js
@@ -14,6 +14,16 @@ HierarchyModeling.prototype.load = function(data) {
   autoLayout(data);
 
   const root = this._canvas.getRootElement();
+
+  if (this._nodes) {
+    Object.values(this._edges || []).forEach(e => {
+      this._modeling.removeConnection(e.connection);
+    });
+    Object.values(this._nodes).forEach(n => {
+      this._modeling.removeShape(n);
+    });
+  }
+
   const nodes = {};
   const edges = [];
 

--- a/lib/features/hierarchy/HierarchyRenderer.js
+++ b/lib/features/hierarchy/HierarchyRenderer.js
@@ -59,7 +59,9 @@ HierarchyRenderer.prototype.drawShape = function(parent, element) {
 };
 
 HierarchyRenderer.prototype.drawConnection = function(parent, connection) {
-  const path = connection.waypoints.map((p, idx) => (idx ? 'L' : 'M') + p.x + ',' + p.y).join(' ');
+  const path = connection.waypoints
+    .map((p, idx) => (idx ? 'L' : 'M') + p.x + ',' + p.y)
+    .join(' ');
   const line = svgCreate('path');
   svgAttr(line, {
     d: path,
@@ -73,17 +75,14 @@ HierarchyRenderer.prototype.drawConnection = function(parent, connection) {
   const bo = connection.businessObject || {};
   if (bo.label) {
     const mid = getConnectionMid(connection);
-    const start = connection.waypoints[0];
-    const end = connection.waypoints[connection.waypoints.length - 1];
-    const width = Math.abs(end.x - start.x) - 10;
-
-    const layout = this._textUtil.layoutText(bo.label, { box: { width, height: 40 }, fitBox: true });
-
-    const text = layout.element;
+    const text = svgCreate('text');
     svgAttr(text, {
-      transform: 'translate(' + (mid.x - layout.dimensions.width / 2) + ',' + (mid.y - layout.dimensions.height / 2 - 5) + ')',
+      x: mid.x,
+      y: mid.y - 5,
+      'text-anchor': 'middle',
       'font-size': '12'
     });
+    text.textContent = bo.label;
     svgAppend(parent, text);
   }
 


### PR DESCRIPTION
## Summary
- reconnect elements after layout change to force rerender
- clean old shapes and connections when loading hierarchy data
- make connection labels rendered as plain text without size limits
- pick connection layout (horizontal or vertical) based on element orientation

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da62e56ac8331ad05e063b604a8da