### PR TITLE
Add UmlLayouter and shape stacking

### DIFF
--- a/lib/features/modeling/cmd/CreateShapeHandler.js
+++ b/lib/features/modeling/cmd/CreateShapeHandler.js
@@ -8,6 +8,7 @@ import { assign } from 'min-dash';
  */
 
 var round = Math.round;
+var STACK_OFFSET = 20;
 
 
 /**
@@ -57,6 +58,28 @@ CreateShapeHandler.prototype.execute = function(context) {
       x: positionOrBounds.x - round(shape.width / 2),
       y: positionOrBounds.y - round(shape.height / 2)
     });
+  }
+
+  // reposition if a sibling exists at the same horizontal level
+  if (parent && Array.isArray(parent.children)) {
+    var maxBottom = null;
+
+    parent.children.forEach(function(sibling) {
+      if (sibling === shape) {
+        return;
+      }
+
+      if (Math.abs((sibling.x || 0) - shape.x) < STACK_OFFSET) {
+        var bottom = sibling.y + (sibling.height || 0);
+        if (maxBottom === null || bottom > maxBottom) {
+          maxBottom = bottom;
+        }
+      }
+    });
+
+    if (maxBottom !== null && shape.y < maxBottom) {
+      shape.y = maxBottom + STACK_OFFSET;
+    }
   }
 
   // (2) add to canvas

--- a/lib/features/modeling/index.js
+++ b/lib/features/modeling/index.js
@@ -4,7 +4,7 @@ import SelectionModule from '../selection';
 import RulesModule from '../rules';
 
 import Modeling from './Modeling';
-import ManhattanLayouter from '../../layout/ManhattanLayouter';
+import UmlLayouter from '../../layout/UmlLayouter';
 
 
 /**
@@ -19,5 +19,5 @@ export default {
   ],
   __init__: [ 'modeling' ],
   modeling: [ 'type', Modeling ],
-  layouter: [ 'type', ManhattanLayouter ]
+  layouter: [ 'type', UmlLayouter ]
 };

--- a/lib/layout/UmlLayouter.js
+++ b/lib/layout/UmlLayouter.js
@@ -1,0 +1,69 @@
+import { getMid } from './LayoutUtil';
+import { connectRectangles, repairConnection } from './ManhattanLayout';
+
+/**
+ * Custom layouter that exposes additional behavior for UML diagrams.
+ *
+ * @param {import('./ConnectionDocking').default} connectionDocking
+ * @param {import('../core/EventBus').default} eventBus
+ * @param {import('../core/Canvas').default} canvas
+ * @param {import('../draw/GraphicsFactory').default} graphicsFactory
+ */
+export default function UmlLayouter(connectionDocking, eventBus, canvas, graphicsFactory) {
+  this.connectionDocking = connectionDocking;
+  this.eventBus = eventBus;
+  this._canvas = canvas;
+  this._graphicsFactory = graphicsFactory;
+}
+
+UmlLayouter.$inject = [ 'connectionDocking', 'eventBus', 'canvas', 'graphicsFactory' ];
+
+/**
+ * Layout the connection by utilizing manhattan routing.
+ * Includes logic for manually adjusted connections.
+ *
+ * @param {import('../core/Types').ConnectionLike} connection
+ * @param {import('./BaseLayouter').LayoutConnectionHints} [hints]
+ *
+ * @return {import('../util/Types').Point[]}
+ */
+UmlLayouter.prototype.layoutConnection = function(connection, hints) {
+  hints = hints || {};
+
+  const source = connection.source;
+  const target = connection.target;
+  const oldWaypoints = connection.waypoints || [];
+
+  // mark connection as custom when user moves a segment
+  this.eventBus.on('connectionSegment.move.move', () => {
+    if (!connection.businessObject.custom) {
+      connection.businessObject.custom = true;
+    }
+  });
+
+  if (
+    connection.businessObject?.custom &&
+    ((hints.connectionStart && !hints.connectionEnd) || (!hints.connectionStart && hints.connectionEnd))
+  ) {
+    const rawStart = hints.connectionStart !== false ? hints.connectionStart : oldWaypoints[0];
+    const rawEnd = hints.connectionEnd !== false ? hints.connectionEnd : oldWaypoints[oldWaypoints.length - 1];
+
+    let newWaypoints = repairConnection(
+      source,
+      target,
+      rawStart,
+      rawEnd,
+      oldWaypoints,
+      {
+        connectionStart: !!hints.connectionStart,
+        connectionEnd: !!hints.connectionEnd
+      }
+    );
+
+    connection.waypoints = newWaypoints;
+    newWaypoints = this.connectionDocking.getCroppedWaypoints(connection, source, target);
+    return newWaypoints;
+  }
+
+  return connectRectangles(source, target, getMid(source), getMid(target));
+};


### PR DESCRIPTION
## Summary
- introduce `UmlLayouter` to keep manually adjusted connection segments
- use `UmlLayouter` for modeling
- stack shapes vertically if they would overlap when created

## Testing
- `npm test` *(fails: karma not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da91b65f88331a70cc2e6e2db473d